### PR TITLE
Add assert_contain

### DIFF
--- a/assert.sh
+++ b/assert.sh
@@ -202,10 +202,35 @@ assert_contain() {
     msg="$3"
   fi
 
+  if [ -z "${needle:+x}" ]; then
+    return 0;
+  fi
+
   if [ -z "${haystack##*$needle*}" ]; then
     return 0
   else
     [ "${#msg}" -gt 0 ] && log_failure "$haystack doesn't contain $needle :: $msg" || true
+    return 1
+  fi
+}
+
+assert_not_contain() {
+  local haystack="$1"
+  local needle="$2"
+  local msg
+
+  if [ "$#" -ge 3 ]; then
+    msg="$3"
+  fi
+
+  if [ -z "${needle:+x}" ]; then
+    return 0;
+  fi
+
+  if [ "${haystack##*$needle*}" ]; then
+    return 0
+  else
+    [ "${#msg}" -gt 0 ] && log_failure "$haystack contains $needle :: $msg" || true
     return 1
   fi
 }

--- a/assert.sh
+++ b/assert.sh
@@ -27,7 +27,7 @@ BOLD=$(tput bold)
 
 log_header() {
   printf "\n${BOLD}${MAGENTA}==========  %s  ==========${NORMAL}\n" "$@" >&2
-  }
+}
 
 log_success() {
   printf "${GREEN}✔ %s${NORMAL}\n" "$@" >&2
@@ -191,4 +191,21 @@ assert_not_empty() {
 
   assert_not_eq "" "$actual" "$msg"
   return "$?"
+}
+
+assert_contain() {
+  local haystack="$1"
+  local needle="$2"
+  local msg
+
+  if [ "$#" -ge 3 ]; then
+    msg="$3"
+  fi
+
+  if [ -z "${haystack##*$needle*}" ]; then
+    return 0
+  else
+    [ "${#msg}" -gt 0 ] && log_failure "$haystack doesn't contain $needle :: $msg" || true
+    return 1
+  fi
 }

--- a/test_assert.sh
+++ b/test_assert.sh
@@ -232,7 +232,7 @@ test_assert_contain() {
 
   assert_contain "haystack" "needle"
   if [ "$?" == 1 ]; then
-    log_success "assert_contain returns 1 if the substring is not in the haystack"
+    log_success "assert_contain returns 1 if the needle is not in the haystack"
   else
     log_failure "assert_contain does not work"
   fi
@@ -264,6 +264,101 @@ test_assert_contain() {
   else
     log_failure "assert_contain does not work"
   fi
+
+  assert_contain "foo\nbar\nhello\nworld" "foo"
+  if [ "$?" == 0 ]; then
+    log_success "assert_contain returns 0 if the needle matches the first haystack line"
+  else
+    log_failure "assert_contain does not work"
+  fi
+
+  assert_contain "foo\nbar\nhello\nworld" "bar"
+  if [ "$?" == 0 ]; then
+    log_success "assert_contain returns 0 if the needle matches the second haystack line"
+  else
+    log_failure "assert_contain does not work"
+  fi
+
+  assert_contain "foo\nbar\nhello\nworld" "ell"
+  if [ "$?" == 0 ]; then
+    log_success "assert_contain returns 0 if the needle is on the third haystack line"
+  else
+    log_failure "assert_contain does not work"
+  fi
+
+  assert_contain "foo\nbar\nhello\nworld" "barbecue"
+  if [ "$?" == 1 ]; then
+    log_success "assert_contain returns 1 if the needle is not in a multi-line haystack"
+  else
+    log_failure "assert_contain does not work"
+  fi
+}
+
+test_assert_not_contain() {
+  log_header "Test :: assert_not_contain"
+
+  assert_not_contain "haystack" "needle"
+  if [ "$?" == 0 ]; then
+    log_success "assert_not_contain returns 0 if the needle is not in the haystack"
+  else
+    log_failure "assert_not_contain does not work"
+  fi
+
+  assert_not_contain "haystack"
+  if [ "$?" == 0 ]; then
+    log_success "assert_not_contain returns 0 if no needle is given"
+  else
+    log_failure "assert_not_contain does not work"
+  fi
+
+  assert_not_contain "haystack" "stack"
+  if [ "$?" == 1 ]; then
+    log_success "assert_not_contain returns 1 if the haystack ends in the needle"
+  else
+    log_failure "assert_not_contain does not work"
+  fi
+
+  assert_not_contain "haystack" "hay"
+  if [ "$?" == 1 ]; then
+    log_success "assert_not_contain returns 1 if the haystack starts with the needle"
+  else
+    log_failure "assert_not_contain does not work"
+  fi
+
+  assert_not_contain "haystack" "aysta"
+  if [ "$?" == 1 ]; then
+    log_success "assert_not_contain returns 1 if the needle is somewhere in the middle of the haystack"
+  else
+    log_failure "assert_not_contain does not work"
+  fi
+
+  assert_not_contain "foo\nbar\nhello\nworld" "foo"
+  if [ "$?" == 1 ]; then
+    log_success "assert_not_contain returns 1 if the needle matches the first haystack line"
+  else
+    log_failure "assert_not_contain does not work"
+  fi
+
+  assert_not_contain "foo\nbar\nhello\nworld" "bar"
+  if [ "$?" == 1 ]; then
+    log_success "assert_not_contain returns 1 if the needle matches the second haystack line"
+  else
+    log_failure "assert_not_contain does not work"
+  fi
+
+  assert_not_contain "foo\nbar\nhello\nworld" "ell"
+  if [ "$?" == 1 ]; then
+    log_success "assert_not_contain returns 1 if the needle is on the third haystack line"
+  else
+    log_failure "assert_not_contain does not work"
+  fi
+
+  assert_not_contain "foo\nbar\nhello\nworld" "barbecue"
+  if [ "$?" == 0 ]; then
+    log_success "assert_not_contain returns 0 if the needle is not in a multi-line haystack"
+  else
+    log_failure "assert_not_contain does not work"
+  fi
 }
 
 
@@ -278,3 +373,4 @@ test_assert_array_not_eq
 test_assert_empty
 test_assert_not_empty
 test_assert_contain
+test_assert_not_contain

--- a/test_assert.sh
+++ b/test_assert.sh
@@ -227,6 +227,45 @@ test_assert_not_empty() {
   fi
 }
 
+test_assert_contain() {
+  log_header "Test :: assert_contain"
+
+  assert_contain "haystack" "needle"
+  if [ "$?" == 1 ]; then
+    log_success "assert_contain returns 1 if the substring is not in the haystack"
+  else
+    log_failure "assert_contain does not work"
+  fi
+
+  assert_contain "haystack"
+  if [ "$?" == 0 ]; then
+    log_success "assert_contain returns 0 if no needle is given"
+  else
+    log_failure "assert_contain does not work"
+  fi
+
+  assert_contain "haystack" "stack"
+  if [ "$?" == 0 ]; then
+    log_success "assert_contain returns 0 if the haystack ends in the needle"
+  else
+    log_failure "assert_contain does not work"
+  fi
+
+  assert_contain "haystack" "hay"
+  if [ "$?" == 0 ]; then
+    log_success "assert_contain returns 0 if the haystack starts with the needle"
+  else
+    log_failure "assert_contain does not work"
+  fi
+
+  assert_contain "haystack" "aysta"
+  if [ "$?" == 0 ]; then
+    log_success "assert_contain returns 0 if the needle is somewhere in the middle of the haystack"
+  else
+    log_failure "assert_contain does not work"
+  fi
+}
+
 
 # test calls
 
@@ -238,3 +277,4 @@ test_assert_array_eq
 test_assert_array_not_eq
 test_assert_empty
 test_assert_not_empty
+test_assert_contain


### PR DESCRIPTION
The functionality in this PR is heavily based on the following stack exchange answer: https://stackoverflow.com/a/20460402

---

`assert_contain` allows checking for keywords in a program's output, simplifying tests for programs with a lot of output where only some keywords matter.