### PR TITLE
Surpress errors when ncurses/tput is missing

### DIFF
--- a/assert.sh
+++ b/assert.sh
@@ -19,11 +19,19 @@
 ##
 #####################################################################
 
-RED=$(tput setaf 1)
-GREEN=$(tput setaf 2)
-MAGENTA=$(tput setaf 5)
-NORMAL=$(tput sgr0)
-BOLD=$(tput bold)
+if command -v tput &>/dev/null; then
+  RED=$(tput setaf 1)
+  GREEN=$(tput setaf 2)
+  MAGENTA=$(tput setaf 5)
+  NORMAL=$(tput sgr0)
+  BOLD=$(tput bold)
+else
+  RED=
+  GREEN=
+  MAGENTA=
+  NORMAL=
+  BOLD=
+fi
 
 log_header() {
   printf "\n${BOLD}${MAGENTA}==========  %s  ==========${NORMAL}\n" "$@" >&2

--- a/assert.sh
+++ b/assert.sh
@@ -26,11 +26,11 @@ if command -v tput &>/dev/null; then
   NORMAL=$(tput sgr0)
   BOLD=$(tput bold)
 else
-  RED=
-  GREEN=
-  MAGENTA=
-  NORMAL=
-  BOLD=
+  RED=$(echo -en "\e[31m")
+  GREEN=$(echo -en "\e[32m")
+  MAGENTA=$(echo -en "\e[35m")
+  NORMAL=$(echo -en "\e[00m")
+  BOLD=$(echo -en "\e[01m")
 fi
 
 log_header() {


### PR DESCRIPTION
The errors were encountered when running a minimal docker image (node:10-alpine), because that docker image does not have ncurses installed by default like assert.sh assumes.

As almost all environments containing bash and performing tests support vt100 escape codes, they were chosen over a fallback without colors.

If a fallback without color is preferred, reverting (or not merging) the 2nd commit does the job.