### PR TITLE
tput is not support in non-interactive shells

### DIFF
--- a/assert.sh
+++ b/assert.sh
@@ -19,7 +19,7 @@
 ##
 #####################################################################
 
-if command -v tput &>/dev/null; then
+if command -v tput &>/dev/null && tty -s; then
   RED=$(tput setaf 1)
   GREEN=$(tput setaf 2)
   MAGENTA=$(tput setaf 5)


### PR DESCRIPTION
Before in non-interactive shells `source assert.sh` throws:

> tput: No value for $TERM and no -T specified

Docker could be used as an example and simple reproduction for the error:

> $ docker run -v `pwd`:/root node:10 bash -c "source /root/assert.sh"
> tput: No value for $TERM and no -T specified
> tput: No value for $TERM and no -T specified
> tput: No value for $TERM and no -T specified
> tput: No value for $TERM and no -T specified
> tput: No value for $TERM and no -T specified

`tty -s` restricts usage of `tput` to interactive shells.