### PR TITLE
Ensure `assert_contain` prints error message when `haystack` is empty

### DIFF
--- a/assert.sh
+++ b/assert.sh
@@ -170,8 +170,8 @@ assert_contain() {
     return 0;
   fi
 
-  if [ -z "$haystack" ]; then
-    return 1;
+  if ! assert_not_empty "$haystack" "$msg"; then
+    return 1
   fi
 
   if [ -z "${haystack##*$needle*}" ]; then


### PR DESCRIPTION
Although it returns an error when `haystack` is empty, it doesn't print a failure message to indicate this unlike every other assertion.

It's easier to delegate to the _existing_ `assert_not_empty` to print if necessary.

Introduced in https://github.com/torokmark/assert.sh/pull/13